### PR TITLE
Fixed fatal unrecoverable error if selling lot is full and fixed error on selling unowned car

### DIFF
--- a/client/main.lua
+++ b/client/main.lua
@@ -280,14 +280,14 @@ CreateThread(function()
                     DrawText3Ds(Config.SellVehicleBack.x, Config.SellVehicleBack.y, Config.SellVehicleBack.z, '[~g~E~w~] - Sell Vehicle To Dealer For ~g~$'..math.floor(sellVehData.price / 2))
                     if IsControlJustPressed(0, 38) then
                         QBCore.Functions.TriggerCallback('qb-garage:server:checkVehicleOwner', function(owned, balance)
-                            if balance < 1 then
-                                if owned then
+                            if owned then
+                                if balance < 1 then
                                     SellToDealer(sellVehData, GetVehiclePedIsIn(ped))
                                 else
-                                    QBCore.Functions.Notify('This is not your vehicle..', 'error', 3500)
+                                    QBCore.Functions.Notify('You must finish paying off this vehicle, Before you can sell it..', 'error', 3500)
                                 end
                             else
-                                QBCore.Functions.Notify('You must finish paying off this vehilce, Before you can sell it..', 'error', 3500)
+                                QBCore.Functions.Notify('This is not your vehicle..', 'error', 3500)
                             end
                         end, sellVehData.plate)
                     end
@@ -354,14 +354,20 @@ CreateThread(function()
                         if IsControlJustPressed(0, 38) then
                             local VehiclePlate = QBCore.Functions.GetPlate(GetVehiclePedIsIn(ped))
                             QBCore.Functions.TriggerCallback('qb-garage:server:checkVehicleOwner', function(owned, balance)
-                                if balance < 1 then
-                                    if owned then
-                                        openSellContract(true)
+                                if owned then
+                                    if balance < 1 then 
+                                        QBCore.Functions.TriggerCallback('qb-occasions:server:getVehicles', function(vehicles)
+                                            if vehicles == nil or #vehicles < #Config.OccasionSlots then
+                                                openSellContract(true)
+                                            else
+                                                QBCore.Functions.Notify('There is not space for your car on the lot!', 'error', 3500)
+                                            end
+                                    end)
                                     else
-                                        QBCore.Functions.Notify('This is not your vehicle..', 'error', 3500)
+                                        QBCore.Functions.Notify('You must finish paying off this vehicle, Before you can sell it..', 'error', 3500)
                                     end
                                 else
-                                    QBCore.Functions.Notify('You must finish paying off this vehilce, Before you can sell it..', 'error', 3500)
+                                    QBCore.Functions.Notify('This is not your vehicle..', 'error', 3500)
                                 end
                             end, VehiclePlate)
                         end


### PR DESCRIPTION
Check implemented to ensure there is space on the lot for the car to be

The balance check was carried out before the owned check which will fail for an unowned car as the vehicle will not be pesent in the DB.

Fixed another issue where if the selling lot was full and another user added their car, the car would be moved table, then when the resource tried to spawn the cars it would not be able to find a place to display the car, then the resource would be stuck in a failure loop.

To resolve this I have added a check before a user can sell their car.

Fixes #22 
