### PR TITLE
Fix exploit and change keybinds

### DIFF
--- a/client/main.lua
+++ b/client/main.lua
@@ -108,18 +108,18 @@ local function SellToDealer(sellVehData, vehicleHash)
         local keepGoing = true
         while keepGoing do
             DisableControlAction(0, 38, true)
-            
-            local coords = GetEntityCoords(vehicleHash)
-            DrawText3Ds(coords.x, coords.y, coords.z + 1.6, '~g~7~w~ - Confirm / ~r~8~w~ - Cancel ~g~')
 
-            if IsDisabledControlJustPressed(0, 161) then
+            local coords = GetEntityCoords(vehicleHash)
+            DrawText3Ds(coords.x, coords.y, coords.z + 1.6, '~g~Y~w~ - Confirm / ~r~N~w~ - Cancel ~g~')
+
+            if IsDisabledControlJustPressed(0, 246) then
                 TriggerServerEvent('qb-occasions:server:sellVehicleBack', sellVehData)
                 QBCore.Functions.DeleteVehicle(vehicleHash)
 
                 keepGoing = false
             end
 
-            if IsDisabledControlJustPressed(0, 162) then
+            if IsDisabledControlJustPressed(0, 306) then
                 keepGoing = false
             end
 

--- a/client/main.lua
+++ b/client/main.lua
@@ -107,6 +107,8 @@ local function SellToDealer(sellVehData, vehicleHash)
     CreateThread(function()
         local keepGoing = true
         while keepGoing do
+            DisableControlAction(0, 38, true)
+            
             local coords = GetEntityCoords(vehicleHash)
             DrawText3Ds(coords.x, coords.y, coords.z + 1.6, '~g~7~w~ - Confirm / ~r~8~w~ - Cancel ~g~')
 


### PR DESCRIPTION
Previously a player could spam `E` to trigger sell back. After confirming with `7` the player would receive the money for each time they pressed `E`. 

I additionally changed the confirm keybinds to `Y` and `N` for Yes and No. I thought this made more sense than 7 and 8. 