### PR TITLE
[FIX] Sell vehicle back fix

### DIFF
--- a/server/main.lua
+++ b/server/main.lua
@@ -80,10 +80,10 @@ end)
 RegisterNetEvent('qb-occasions:server:sellVehicleBack', function(vehData)
     local src = source
     local Player = QBCore.Functions.GetPlayer(src)
-    local price
+    local price = 0
     local plate = vehData.plate
     for k, v in pairs(QBCore.Shared.Vehicles) do
-        if tonumber(v["hash"]) == vehData.model then
+        if GetHashKey(v["hash"]) == vehData.model then
             price = tonumber(v["price"])
         end
     end


### PR DESCRIPTION
Fixing the server error when trying to resell vehicle instantly.

Error message: `[script:qb-vehiclesal] SCRIPT ERROR: @qb-vehiclesales/server/main.lua:83: attempt to perform arithmetic on a nil value (field 'price')`