### PR TITLE
Fix for Warning: Could not find file

### DIFF
--- a/fxmanifest.lua
+++ b/fxmanifest.lua
@@ -27,7 +27,6 @@ server_scripts {
 }
 
 files {
-    'html/reset.css',
     'html/logo.svg',
     'html/ui.css',
     'html/ui.html',


### PR DESCRIPTION
This fixes the console warning being thrown when starting the script.